### PR TITLE
Have the Battle Tower replace the full row of treasure nodes

### DIFF
--- a/BattleTowers/src/main/java/BattleTowers/events/TowerEvent.java
+++ b/BattleTowers/src/main/java/BattleTowers/events/TowerEvent.java
@@ -329,10 +329,6 @@ public class TowerEvent extends PhasedEvent {
         private float fadeTimer = fadeTime;
 
         @Override
-        public void begin(PhasedEvent event) {
-        }
-
-        @Override
         public void update() {
             if (fadeTimer > 0) {
                 fadeTimer -= Gdx.graphics.getDeltaTime();
@@ -354,12 +350,6 @@ public class TowerEvent extends PhasedEvent {
             newRoom.onPlayerEntry();
             AbstractDungeon.fadeIn();
         }
-
-        @Override
-        public void render(SpriteBatch sb) {}
-
-        @Override
-        public void renderAboveTopPanel(SpriteBatch sb) {}
     }
 
     /*

--- a/BattleTowers/src/main/java/BattleTowers/events/TowerEvent.java
+++ b/BattleTowers/src/main/java/BattleTowers/events/TowerEvent.java
@@ -2,6 +2,7 @@ package BattleTowers.events;
 
 import BattleTowers.events.phases.*;
 import BattleTowers.minimap.Minimap;
+import BattleTowers.patches.node.TowerGeneration;
 import BattleTowers.room.BattleTowerRoom;
 import BattleTowers.towers.BattleTower;
 import basemod.Pair;
@@ -11,6 +12,7 @@ import com.badlogic.gdx.math.Interpolation;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.events.GenericEventDialog;
 import com.megacrit.cardcrawl.localization.EventStrings;
 import com.megacrit.cardcrawl.random.Random;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
@@ -34,6 +36,7 @@ public class TowerEvent extends PhasedEvent {
 
     private static final String TOWER_CHOICE_PHASE = "TOWER_CHOICE";
     private static final String MAP_PHASE = "MAP";
+    private static final String CHEST_PHASE = "CHEST";
 
     private static final int NUM_OPTIONS = 3; //it seems like it'll probably just be 1.
     public int chosenTower = -1; //For saving?
@@ -60,8 +63,14 @@ public class TowerEvent extends PhasedEvent {
                 }
             });
         }
+        if (TowerGeneration.fullRowMode) {
+            choice.addOption(OPTIONS[1], (index) -> {
+                this.transitionKey(CHEST_PHASE);
+            });
+        }
         registerPhase(TOWER_CHOICE_PHASE, choice);
         registerPhase(MAP_PHASE, new InteractionPhase(mapHandler));
+        registerPhase(CHEST_PHASE, new InteractionPhase(new ChestHandler()));
 
         transitionKey(TOWER_CHOICE_PHASE);
     }
@@ -313,6 +322,24 @@ public class TowerEvent extends PhasedEvent {
             this.tower = t;
             map.generate(tower, towerRng);
         }
+    }
+
+    private static class ChestHandler implements InteractionPhase.InteractionHandler {
+        @Override
+        public void begin(PhasedEvent event) {
+            GenericEventDialog.hide();
+            AbstractDungeon.rs = AbstractDungeon.RenderScene.NORMAL;
+            AbstractRoom newRoom = new TreasureRoom();
+            AbstractDungeon.getCurrMapNode().room = newRoom;
+            newRoom.onPlayerEntry();
+        }
+
+        @Override
+        public void update() {}
+        @Override
+        public void render(SpriteBatch sb) {}
+        @Override
+        public void renderAboveTopPanel(SpriteBatch sb) {}
     }
 
     /*

--- a/BattleTowers/src/main/java/BattleTowers/events/TowerEvent.java
+++ b/BattleTowers/src/main/java/BattleTowers/events/TowerEvent.java
@@ -345,7 +345,10 @@ public class TowerEvent extends PhasedEvent {
             logger.info("Going to treasure room");
             GenericEventDialog.hide();
             AbstractDungeon.rs = AbstractDungeon.RenderScene.NORMAL;
+            AbstractRoom currentRoom = AbstractDungeon.getCurrRoom();
             AbstractRoom newRoom = new TreasureRoom();
+            newRoom.setMapSymbol(currentRoom.getMapSymbol());
+            newRoom.setMapImg(currentRoom.getMapImg(), currentRoom.getMapImgOutline());
             AbstractDungeon.getCurrMapNode().room = newRoom;
             newRoom.onPlayerEntry();
             AbstractDungeon.fadeIn();

--- a/BattleTowers/src/main/java/BattleTowers/events/TowerEvent.java
+++ b/BattleTowers/src/main/java/BattleTowers/events/TowerEvent.java
@@ -325,19 +325,39 @@ public class TowerEvent extends PhasedEvent {
     }
 
     private static class ChestHandler implements InteractionPhase.InteractionHandler {
+        private final float fadeTime = Settings.FAST_MODE ? 0.25f : 0.7f;
+        private float fadeTimer = fadeTime;
+
         @Override
         public void begin(PhasedEvent event) {
+        }
+
+        @Override
+        public void update() {
+            if (fadeTimer > 0) {
+                fadeTimer -= Gdx.graphics.getDeltaTime();
+                AbstractDungeon.fadeColor.a = Interpolation.fade.apply(1.0F, 0.0F, fadeTimer / fadeTime);
+                if (fadeTimer <= 0.0F) {
+                    fadeTimer = 0.0F;
+                    AbstractDungeon.fadeColor.a = 1.0F;
+                    this.goToTreasureRoom();
+                }
+            }
+        }
+
+        private void goToTreasureRoom() {
+            logger.info("Going to treasure room");
             GenericEventDialog.hide();
             AbstractDungeon.rs = AbstractDungeon.RenderScene.NORMAL;
             AbstractRoom newRoom = new TreasureRoom();
             AbstractDungeon.getCurrMapNode().room = newRoom;
             newRoom.onPlayerEntry();
+            AbstractDungeon.fadeIn();
         }
 
         @Override
-        public void update() {}
-        @Override
         public void render(SpriteBatch sb) {}
+
         @Override
         public void renderAboveTopPanel(SpriteBatch sb) {}
     }

--- a/BattleTowers/src/main/java/BattleTowers/patches/node/TowerGeneration.java
+++ b/BattleTowers/src/main/java/BattleTowers/patches/node/TowerGeneration.java
@@ -21,6 +21,7 @@ import static com.megacrit.cardcrawl.dungeons.AbstractDungeon.mapRng;
         method = "generateMap"
 )
 public class TowerGeneration {
+    private static int TOWER_ACT_NUMBER = 2;
     public static boolean DEBUG = true;
     public static float appearRate = 1.0f; //config option?
     public static boolean fullRowMode = true; //config option, or just make this always the behavior
@@ -34,8 +35,7 @@ public class TowerGeneration {
             locator = Locator.class
     )
     public static void GenerateTower() {
-        //Should it be any act 2 or just the city?
-        if ((DEBUG || TheCity.ID.equals(AbstractDungeon.id)) && mapRng.randomBoolean(appearRate)) {
+        if ((DEBUG || AbstractDungeon.actNum == TOWER_ACT_NUMBER) && mapRng.randomBoolean(appearRate)) {
             if (fullRowMode) {
                 replaceFullRow();
             }

--- a/BattleTowers/src/main/java/BattleTowers/patches/node/TowerGeneration.java
+++ b/BattleTowers/src/main/java/BattleTowers/patches/node/TowerGeneration.java
@@ -6,6 +6,7 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.dungeons.TheCity;
 import com.megacrit.cardcrawl.map.MapEdge;
 import com.megacrit.cardcrawl.map.MapRoomNode;
+import com.megacrit.cardcrawl.rooms.TreasureRoom;
 import javassist.CtBehavior;
 import org.apache.logging.log4j.Logger;
 
@@ -22,6 +23,7 @@ import static com.megacrit.cardcrawl.dungeons.AbstractDungeon.mapRng;
 public class TowerGeneration {
     public static boolean DEBUG = true;
     public static float appearRate = 1.0f; //config option?
+    public static boolean fullRowMode = true; //config option, or just make this always the behavior
 
     /*
         Purpose:
@@ -34,72 +36,92 @@ public class TowerGeneration {
     public static void GenerateTower() {
         //Should it be any act 2 or just the city?
         if ((DEBUG || TheCity.ID.equals(AbstractDungeon.id)) && mapRng.randomBoolean(appearRate)) {
-            //Time to catalogue some paths
-            Map<MapRoomNode, Set<MapRoomNode>> prior = scorePrior(8);
-            Map<MapRoomNode, Set<MapRoomNode>> following = scoreFollowing(8);
-
-            List<MapRoomNode> possible = new ArrayList<>();
-            int highScore = 0, score;
-            logger.info("Scoring:");
-            for (MapRoomNode n : AbstractDungeon.map.get(8)) {
-                score = prior.getOrDefault(n, Collections.emptySet()).size();
-                score += following.getOrDefault(n, Collections.emptySet()).size();
-                logger.info("("+n.x+","+n.y+") - " + score);
-                if (score > highScore) {
-                    possible.clear();
-                    highScore = score;
-                }
-                if (score == highScore) {
-                    possible.add(n);
-                }
-            }
-
-            if (possible.isEmpty()) {
-                logger.error("Somehow found no possible nodes?");
+            if (fullRowMode) {
+                replaceFullRow();
             }
             else {
-                MapRoomNode chosen = possible.get(mapRng.random(possible.size() - 1));
-                chosen.setRoom(new BattleTowerRoom());
+                replaceOneNode();
+            }
+        }
+    }
 
-                //add following edges
-                Set<MapRoomNode> connected = following.get(chosen);
+    private static void replaceFullRow() {
+        for (MapRoomNode n : AbstractDungeon.map.get(8)) {
+            // In case some other mod does something to these rooms, only replace treasure rooms
+            if (n.room instanceof TreasureRoom) {
+                n.setRoom(new BattleTowerRoom());
+            } else {
+                logger.info("Found a non-treasure node in the middle of the map. Skipping it for battle tower replacement.");
+            }
+        }
+    }
+
+    private static void replaceOneNode() {
+        //Time to catalogue some paths
+        Map<MapRoomNode, Set<MapRoomNode>> prior = scorePrior(8);
+        Map<MapRoomNode, Set<MapRoomNode>> following = scoreFollowing(8);
+
+        List<MapRoomNode> possible = new ArrayList<>();
+        int highScore = 0, score;
+        logger.info("Scoring:");
+        for (MapRoomNode n : AbstractDungeon.map.get(8)) {
+            score = prior.getOrDefault(n, Collections.emptySet()).size();
+            score += following.getOrDefault(n, Collections.emptySet()).size();
+            logger.info("("+n.x+","+n.y+") - " + score);
+            if (score > highScore) {
                 possible.clear();
-                for (MapRoomNode n : connected) {
-                    if (n.y == chosen.y + 1)
-                        possible.add(n);
-                }
+                highScore = score;
+            }
+            if (score == highScore) {
+                possible.add(n);
+            }
+        }
 
-                if (!possible.isEmpty()) {
-                    for (MapRoomNode n : possible) {
-                        if (!chosen.isConnectedTo(n)) {
-                            chosen.addEdge(new MapEdge(chosen.x, chosen.y, chosen.offsetX, chosen.offsetY, n.x, n.y, n.offsetX, n.offsetY, false));
-                        }
-                    }
-                    chosen.getEdges().sort(MapEdge::compareTo);
-                }
-                else {
-                    logger.error("Somehow found no possible following nodes?");
-                }
+        if (possible.isEmpty()) {
+            logger.error("Somehow found no possible nodes?");
+        }
+        else {
+            MapRoomNode chosen = possible.get(mapRng.random(possible.size() - 1));
+            chosen.setRoom(new BattleTowerRoom());
 
-                //add preceding edges
-                connected = prior.get(chosen);
-                possible.clear();
-                for (MapRoomNode n : connected) {
-                    if (n.y == chosen.y - 1)
-                        possible.add(n);
-                }
+            //add following edges
+            Set<MapRoomNode> connected = following.get(chosen);
+            possible.clear();
+            for (MapRoomNode n : connected) {
+                if (n.y == chosen.y + 1)
+                    possible.add(n);
+            }
 
-                if (!possible.isEmpty()) {
-                    for (MapRoomNode n : possible) {
-                        if (!n.isConnectedTo(chosen)) {
-                            n.addEdge(new MapEdge(n.x, n.y, n.offsetX, n.offsetY, chosen.x, chosen.y, chosen.offsetX, chosen.offsetY, false));
-                            n.getEdges().sort(MapEdge::compareTo);
-                        }
+            if (!possible.isEmpty()) {
+                for (MapRoomNode n : possible) {
+                    if (!chosen.isConnectedTo(n)) {
+                        chosen.addEdge(new MapEdge(chosen.x, chosen.y, chosen.offsetX, chosen.offsetY, n.x, n.y, n.offsetX, n.offsetY, false));
                     }
                 }
-                else {
-                    logger.error("Somehow found no possible preceding nodes?");
+                chosen.getEdges().sort(MapEdge::compareTo);
+            }
+            else {
+                logger.error("Somehow found no possible following nodes?");
+            }
+
+            //add preceding edges
+            connected = prior.get(chosen);
+            possible.clear();
+            for (MapRoomNode n : connected) {
+                if (n.y == chosen.y - 1)
+                    possible.add(n);
+            }
+
+            if (!possible.isEmpty()) {
+                for (MapRoomNode n : possible) {
+                    if (!n.isConnectedTo(chosen)) {
+                        n.addEdge(new MapEdge(n.x, n.y, n.offsetX, n.offsetY, chosen.x, chosen.y, chosen.offsetX, chosen.offsetY, false));
+                        n.getEdges().sort(MapEdge::compareTo);
+                    }
                 }
+            }
+            else {
+                logger.error("Somehow found no possible preceding nodes?");
             }
         }
     }

--- a/BattleTowers/src/main/java/BattleTowers/patches/node/TowerGeneration.java
+++ b/BattleTowers/src/main/java/BattleTowers/patches/node/TowerGeneration.java
@@ -21,7 +21,7 @@ import static com.megacrit.cardcrawl.dungeons.AbstractDungeon.mapRng;
         method = "generateMap"
 )
 public class TowerGeneration {
-    private static int TOWER_ACT_NUMBER = 2;
+    private static final int TOWER_ACT_NUMBER = 2;
     public static boolean DEBUG = true;
     public static float appearRate = 1.0f; //config option?
     public static boolean fullRowMode = true; //config option, or just make this always the behavior

--- a/BattleTowers/src/main/java/BattleTowers/powers/SlimeFilledRoomPower.java
+++ b/BattleTowers/src/main/java/BattleTowers/powers/SlimeFilledRoomPower.java
@@ -3,6 +3,7 @@ package BattleTowers.powers;
 import BattleTowers.BattleTowers;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.MakeTempCardInDrawPileAction;
+import com.megacrit.cardcrawl.actions.utility.WaitAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.status.Slimed;
 import com.megacrit.cardcrawl.core.AbstractCreature;
@@ -33,7 +34,12 @@ public class SlimeFilledRoomPower extends AbstractPower {
     @Override
     public void onInitialApplication() {
         int slimes = (int)AbstractDungeon.player.masterDeck.group.stream().filter(c -> c.rarity != AbstractCard.CardRarity.CURSE && c.rarity != AbstractCard.CardRarity.BASIC).count();
-        this.addToBot(new MakeTempCardInDrawPileAction(new Slimed(), slimes, true, true));
+        int slimesPerBatch = 5;
+        while (slimes > 0) {
+            this.addToBot(new MakeTempCardInDrawPileAction(new Slimed(), Math.min(slimes, slimesPerBatch), true, true));
+            this.addToBot(new WaitAction(0.1f));
+            slimes -= slimesPerBatch;
+        }
     }
 
     public void onPlayerExhaust(AbstractCard c) {

--- a/BattleTowers/src/main/resources/battleTowersResources/loc/eng/events.json
+++ b/BattleTowers/src/main/resources/battleTowersResources/loc/eng/events.json
@@ -6,7 +6,7 @@
     ],
     "OPTIONS": [
       "[Enter] Oh boy, I can't wait to go inside this tower!",
-      "[Leave] ..."
+      "[Leave] Don't risk it, take the treasure"
     ]
   },
   "${ModID}:Example": {


### PR DESCRIPTION
* Implement replacing the full row of treasure nodes with the tower node (with an option to switch back/make this a config option if we want)
* Add a choice to the tower event to just take the normal treasure chest that would be there (the transition could be slightly cleaner, but it works)
* Have the tower show up in all act 2s (people always want to play with lots of different mods running)
* Improve the Giga Slime status thing along the way