### PR TITLE
Balance tweak for Giga Slime

### DIFF
--- a/BattleTowers/src/main/java/BattleTowers/monsters/GigaSlime.java
+++ b/BattleTowers/src/main/java/BattleTowers/monsters/GigaSlime.java
@@ -44,10 +44,10 @@ public class GigaSlime extends AbstractBTMonster
     private static final int GOOP_SPRAY_STRENGTH = 6;
     private static final int A3_GOOP_SPRAY_STRENGTH = 8;
     private static final int A18_GOOP_SPRAY_STRENGTH = 10;
-    private static final int LESSER_SLAM_DAMAGE = 16;
-    private static final int A3_LESSER_SLAM_DAMAGE = 16;
-    private static final int TACKLE_AND_LICK_DAMAGE = 5;
-    private static final int A3_TACKLE_AND_LICK_DAMAGE = 5;
+    private static final int LESSER_SLAM_DAMAGE = 18;
+    private static final int A3_LESSER_SLAM_DAMAGE = 18;
+    private static final int TACKLE_AND_LICK_DAMAGE = 8;
+    private static final int A3_TACKLE_AND_LICK_DAMAGE = 8;
     private static final int TACKLE_AND_LICK_WEAK_FRAIL = 1;
     private static final int A18_TACKLE_AND_LICK_WEAK_FRAIL = 2;
     private static final int HP_MIN = 163;

--- a/BattleTowers/src/main/java/BattleTowers/powers/SlimeFilledRoomPower.java
+++ b/BattleTowers/src/main/java/BattleTowers/powers/SlimeFilledRoomPower.java
@@ -33,7 +33,7 @@ public class SlimeFilledRoomPower extends AbstractPower {
 
     @Override
     public void onInitialApplication() {
-        int slimes = (int)AbstractDungeon.player.masterDeck.group.stream().filter(c -> c.rarity != AbstractCard.CardRarity.CURSE && c.rarity != AbstractCard.CardRarity.BASIC).count();
+        int slimes = AbstractDungeon.player.masterDeck.group.size() / 2;
         int slimesPerBatch = 5;
         while (slimes > 0) {
             this.addToBot(new MakeTempCardInDrawPileAction(new Slimed(), Math.min(slimes, slimesPerBatch), true, true));

--- a/BattleTowers/src/main/resources/battleTowersResources/loc/eng/powers.json
+++ b/BattleTowers/src/main/resources/battleTowersResources/loc/eng/powers.json
@@ -120,7 +120,7 @@
   "${ModID}:SlimeFilledRoomPower": {
     "NAME": "Slime Filled Room",
     "DESCRIPTIONS": [
-      "At the start of combat, this enemy adds #b1 #ySlimed to your draw pile for each card other than #yCurses and #yBasics. Whenever a #ySlimed is #yExhausted, this enemy loses #b1 #yStrength."
+      "At the start of combat, this enemy adds #b1 #ySlimed to your draw pile for every #b2 cards in your deck. Whenever a #ySlimed is #yExhausted, this enemy loses #b1 #yStrength."
     ]
   },
   "${ModID}:PlayerCurlUpPower": {


### PR DESCRIPTION
Change Slime Filled Room to give half your deck size in slimes, to be less punishing and more consistent. In return, increase Giga Slime's base damage slightly, so that the fight stays challenging.