### PR TITLE
fix: added makeCopy() to Dijinn Cards

### DIFF
--- a/BattleTowers/src/main/java/BattleTowers/cards/DijinnCards/DijinnWrath.java
+++ b/BattleTowers/src/main/java/BattleTowers/cards/DijinnCards/DijinnWrath.java
@@ -4,6 +4,7 @@ import BattleTowers.BattleTowers;
 import BattleTowers.monsters.Dijinn;
 import basemod.AutoAdd;
 import basemod.abstracts.CustomCard;
+import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.localization.CardStrings;
@@ -42,5 +43,9 @@ public class DijinnWrath extends CustomCard {
         dijinn.dijinnWrath();
     }
 
+    @Override
+    public AbstractCard makeCopy(){
+        return new DijinnWrath(this.dijinn, this.magicNumber);
+    }
 
 }

--- a/BattleTowers/src/main/java/BattleTowers/cards/DijinnCards/MakeAWish.java
+++ b/BattleTowers/src/main/java/BattleTowers/cards/DijinnCards/MakeAWish.java
@@ -4,6 +4,7 @@ import BattleTowers.BattleTowers;
 import BattleTowers.monsters.Dijinn;
 import basemod.AutoAdd;
 import basemod.abstracts.CustomCard;
+import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.localization.CardStrings;
@@ -41,5 +42,9 @@ public class MakeAWish extends CustomCard {
         dijinn.makeAWish(magicNumber);
     }
 
+    @Override
+    public AbstractCard makeCopy(){
+        return new MakeAWish(this.dijinn,this.magicNumber);
+    }
 
 }


### PR DESCRIPTION
Added makeCopy to Dijinn Cards.

While these aren't normally in hand and therefore aren't normally copied it can happen.

SayTheSpire for example tries to copy these and crashes.